### PR TITLE
Add Agent Version and OS Fields to Executions

### DIFF
--- a/database/migrations/20250325_agent_version.down.sql
+++ b/database/migrations/20250325_agent_version.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS public.executions DROP COLUMN agent_version;
+ALTER TABLE IF EXISTS public.executions DROP COLUMN os;

--- a/database/migrations/20250325_agent_version.up.sql
+++ b/database/migrations/20250325_agent_version.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS public.executions ADD COLUMN agent_version text;
+ALTER TABLE IF EXISTS public.executions ADD COLUMN os text;

--- a/models/execution.go
+++ b/models/execution.go
@@ -11,4 +11,6 @@ type Execution struct {
 	Details               string     `json:"details,omitempty"`
 	TransactionsProcessed int        `json:"transactions_processed,omitempty"`
 	TransactionsSent      int        `json:"transactions_sent,omitempty"`
+	AgentVersion          string     `json:"agent_version,omitempty"`
+	OS                    string     `json:"os,omitempty"`
 }


### PR DESCRIPTION
This pull request adds two new fields, `agent_version` and `os`, to the `executions` table and updates the relevant code to handle these new fields.