### PR TITLE
Show new server version

### DIFF
--- a/main.go
+++ b/main.go
@@ -278,6 +278,7 @@ func EnvironmentVariablesMiddleware() gin.HandlerFunc {
 			"cronRetentionExpression":  os.Getenv("CRON_RETENTION_EXPRESSION"),
 			"cronStatisticsExpression": os.Getenv("CRON_STATS_EXPRESSION"),
 			"ignoreEmptyExecution":     os.Getenv("IGNORE_EMPTY_EXECUTION"),
+			"latestVersion":            os.Getenv("LATEST_VERSION"),
 		}
 
 		c.Set("env", envVars)

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -14,14 +14,11 @@
               Sponsor
             </a>
           </li>
-          <li class="list-inline-item"><a href="/swagger/index.html" target="_blank" class="link-secondary"
-              rel="noopener">API</a></li>
-          <li class="list-inline-item"><a href="https://txlog.rda.run/docs/server" target="_blank"
-              class="link-secondary" rel="noopener">Documentation</a></li>
+          <li class="list-inline-item"><a href="/swagger/index.html" target="_blank" class="link-secondary" rel="noopener">API</a></li>
+          <li class="list-inline-item"><a href="https://txlog.rda.run/docs/server" target="_blank" class="link-secondary" rel="noopener">Documentation</a></li>
           <li class="list-inline-item"><a href="/license" class="link-secondary">License</a></li>
           <li class="list-inline-item"><a data-bs-toggle="offcanvas" href="#settingsOffcanvas" aria-controls="offcanvasEnd" class="link-secondary">Settings</a></li>
-          <li class="list-inline-item"><a href="https://github.com/txlog/server/tree/v{{ version }}" target="_blank"
-              class="link-secondary" rel="noopener">v{{ version }}</a></li>
+          <li class="list-inline-item"><a href="https://github.com/txlog/server/releases/tag/v{{ version }}" target="_blank" class="link-secondary" rel="noopener">v{{ version }}</a></li>
         </ul>
       </div>
       <div class="col-12 col-lg-auto mt-3 mt-lg-0">

--- a/templates/header.html
+++ b/templates/header.html
@@ -83,6 +83,16 @@
         </li>
       </ul>
       <div class="navbar-nav flex-row order-md-last ms-auto">
+        {{ if ne .Context.Keys.env.latestVersion (printf "v%s" version) }}
+        <div class="nav-item dropdown">
+          <div class="d-none d-xl-block ps-2">
+            <a href="https://github.com/txlog/server/releases/tag/{{ .Context.Keys.env.latestVersion }}" class="badge bg-red text-red-fg">
+              New version available: {{ .Context.Keys.env.latestVersion }}
+              <svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-external-link"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" /><path d="M11 13l9 -9" /><path d="M15 4h5v5" /></svg>
+            </a>
+          </div>
+        </div>
+        {{ end }}
         <div class="nav-item dropdown">
           <div class="d-none d-xl-block ps-2">
             <span class="badge bg-light-lt">{{ .Context.Keys.env.instance }}</span>


### PR DESCRIPTION
If there's a new server version, show a banner on top. Use https://txlog.rda.run/docs/server/version URL to get the latest version available.